### PR TITLE
Add missing dependency to H5PEditor.RadioGroup

### DIFF
--- a/library.json
+++ b/library.json
@@ -37,6 +37,11 @@
       "machineName": "H5PEditor.ShowWhen",
       "majorVersion": 1,
       "minorVersion": 0
+    },
+    {
+      "machineName": "H5PEditor.RadioGroup",
+      "majorVersion": 1,
+      "minorVersion": 1
     }
   ]
 }


### PR DESCRIPTION
Currently, "Shape" is [referencing the radio group widget](https://github.com/h5p/h5p-shape/blob/master/semantics.json#L7) in `semantics.json`, but that is not set as an editor dependency.

When merged in, the dependency will be added. Requires to bump the version number, of course, but that will happen anyway when releasing an update.